### PR TITLE
Update build process for versioning and revert main version to 'dev'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,16 @@ jobs:
         with:
           go-version: '1.21'
 
+      - name: Get version from tag
+        id: vers
+        run: echo "version=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          go build -o ${{ matrix.output }} -ldflags="-s -w" .
+          go build -o ${{ matrix.output }} -ldflags="-s -w -X 'main.version=${{ steps.vers.outputs.version }}'" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
-const version = "1.0.6"
+const version = "dev"
 
 const asciiArt = `
 ███████╗███╗   ██╗██╗   ██╗ ██████╗██╗  ██╗ █████╗ ███╗   ██╗████████╗███████╗██████╗ 


### PR DESCRIPTION
Incorporate versioning from tags into the build process and reset the main version to 'dev' for development purposes.